### PR TITLE
Exclude HTML from language repo statistics.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sudograph-book/** linguist-vendored


### PR DESCRIPTION
The repository gets labeled as `HTML`, which does not do it any justice in my opinion.
By setting the `sudograph-book` directory to `vendored` you can remove it from the language statistics.

---

More info on [overrides](https://github.com/github/linguist/blob/0c7f82f88a2fb482db3a02812cbb4b8aab7308d1/docs/overrides.md#vendored-code).